### PR TITLE
Add helper for Tina branch headers

### DIFF
--- a/app/[...filename]/page.tsx
+++ b/app/[...filename]/page.tsx
@@ -2,24 +2,17 @@ import React from "react";
 import client from "@/tina/__generated__/client";
 import Layout from "@/components/layout/layout";
 import ClientPage from "./client-page";
-import { cookies } from "next/headers";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 
 export default async function Home({
   params,
 }: {
   params: { filename: string[] };
 }) {
-  const cookieStore = await cookies();
-  const data = await client.queries.page({
-    relativePath: `${params.filename.join("/")}.mdx`,
-  },
-    {
-      fetchOptions: {
-        headers: {
-          'x-branch': cookieStore.get('x-branch')?.value || process.env.NEXT_PUBLIC_TINA_BRANCH || 'main',
-        }
-      }
-    });
+  const data = await client.queries.page(
+    { relativePath: `${params.filename.join("/")}.mdx` },
+    await getTinaFetchOptions()
+  );
 
   return (
     <Layout rawPageData={data}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { Inter as FontSans, Lato, Nunito } from "next/font/google";
 import { cn } from "@/lib/utils";
 import client from "@/tina/__generated__/client";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 
 import "@/styles.css";
 
@@ -32,9 +33,10 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const globalQuery = await client.queries.global({
-    relativePath: "index.json",
-  });
+  const globalQuery = await client.queries.global(
+    { relativePath: "index.json" },
+    await getTinaFetchOptions()
+  );
   const global = globalQuery.data.global;
 
   const selectFont = (fontName: string) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,19 +2,12 @@ import React from "react";
 import client from "@/tina/__generated__/client";
 import Layout from "@/components/layout/layout";
 import ClientPage from "./[...filename]/client-page";
-import { cookies } from "next/headers";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 export default async function Home() {
-  const cookieStore = await cookies();
-  const data = await client.queries.page({
-    relativePath: `home.mdx`,
-  },
-    {
-      fetchOptions: {
-        headers: {
-          'x-branch': cookieStore.get('x-branch')?.value || process.env.NEXT_PUBLIC_TINA_BRANCH || 'main',
-        }
-      }
-    });
+  const data = await client.queries.page(
+    { relativePath: `home.mdx` },
+    await getTinaFetchOptions()
+  );
 
   return (
     <Layout rawPageData={data}>

--- a/app/posts/[...filename]/page.tsx
+++ b/app/posts/[...filename]/page.tsx
@@ -2,25 +2,17 @@ import React from "react";
 import client from "@/tina/__generated__/client";
 import Layout from "@/components/layout/layout";
 import PostClientPage from "./client-page";
-import { cookies } from "next/headers";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 
 export default async function PostPage({
   params,
 }: {
   params: { filename: string[] };
 }) {
-  const cookieStore = await cookies();
-  const data = await client.queries.post({
-    relativePath: `${params.filename.join("/")}.mdx`,
-  },
-  {
-    fetchOptions: {
-      headers: {
-          'x-branch': cookieStore.get('x-branch')?.value || process.env.NEXT_PUBLIC_TINA_BRANCH || 'main',
-        }
-    }
-  }
-);
+  const data = await client.queries.post(
+    { relativePath: `${params.filename.join("/")}.mdx` },
+    await getTinaFetchOptions()
+  );
 
 
   return (

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,21 +1,13 @@
 import Layout from "@/components/layout/layout";
 import client from "@/tina/__generated__/client";
 import PostsClientPage from "./client-page";
-import { cookies } from "next/headers";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 
 export default async function PostsPage() {
-  const cookieStore = await cookies();
-  let posts = await client.queries.postConnection({
-    sort: "date",
-    },
-    {
-      fetchOptions: {
-        headers: {
-          'x-branch': cookieStore.get('x-branch')?.value || process.env.NEXT_PUBLIC_TINA_BRANCH || 'main',
-        }
-      }
-    }
-);
+  let posts = await client.queries.postConnection(
+    { sort: "date" },
+    await getTinaFetchOptions()
+  );
   const allPosts = posts;
 
   while (posts.data?.postConnection.pageInfo.hasNextPage) {

--- a/app/posts/topposts.tsx
+++ b/app/posts/topposts.tsx
@@ -1,14 +1,15 @@
 import client from "@/tina/__generated__/client";
+import { getTinaFetchOptions } from "@/lib/tinaFetchOptions";
 import { PostConnection, PostConnectionEdges, Post } from "@/tina/__generated__/types";
 
 
 export default async function TopPosts({ numPosts = 4 }: { numPosts?: number }) {
   console.log("⚡ Fetching TopPosts with numPosts:", numPosts);
 
-  let posts = await client.queries.postConnection({
-    sort: "date",
-    last: numPosts, 
-  });
+  let posts = await client.queries.postConnection(
+    { sort: "date", last: numPosts },
+    await getTinaFetchOptions()
+  );
 
   console.log("✅ Fetched posts count:", posts.data?.postConnection.edges.length);
 

--- a/lib/tinaFetchOptions.ts
+++ b/lib/tinaFetchOptions.ts
@@ -1,0 +1,15 @@
+import { cookies } from "next/headers";
+
+export async function getTinaFetchOptions() {
+  const cookieStore = cookies();
+  return {
+    fetchOptions: {
+      headers: {
+        "x-branch":
+          cookieStore.get("x-branch")?.value ||
+          process.env.NEXT_PUBLIC_TINA_BRANCH ||
+          "main",
+      },
+    },
+  } as const;
+}


### PR DESCRIPTION
## Summary
- centralize x-branch header logic in `getTinaFetchOptions`
- use helper in all server pages and data utilities

## Testing
- `npm run lint`
- `npm run build` *(fails: Client not configured properly. Missing token)*

------
https://chatgpt.com/codex/tasks/task_e_68743571f9f483239e99ddf528135172